### PR TITLE
chore(ci): consume code-foundry v0.27.13

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.27.11
+runtime_ref: v0.27.13
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.27.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.11
+      runtime-ref: v0.27.13
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,9 @@ permissions:
 jobs:
   codeql:
     name: CodeQL
-    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.27.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.11
+      runtime-ref: v0.27.13
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.27.13
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release-pr:
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.27.13
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.27.13
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   security:
     name: Security
-    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.27.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.11
+      runtime-ref: v0.27.13
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.27.11
+    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.27.13
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.11
+      runtime-ref: v0.27.13
       runner: ubuntu-latest
       unit-runner: ubuntu-slim
     secrets: inherit


### PR DESCRIPTION
## Summary

- Upgrade Code Foundry reusable workflows to `v0.27.13`.
- Enable language-aware dependency audit skipping.
- Preserve the custom Slither workflow unchanged.

## Validation

- Bun tests: 56 passing
- Hardhat tests: 174 passing, 3 pending
- TypeScript lint and type-check
- Prettier format check
- Solidity lint: 0 errors, 95 existing warnings
- Solidity compilation