### PR TITLE
fix(slither): stabilize SARIF category

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.27.13
+runtime_ref: v0.27.14
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.27.14
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.13
+      runtime-ref: v0.27.14
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,9 @@ permissions:
 jobs:
   codeql:
     name: CodeQL
-    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.27.14
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.13
+      runtime-ref: v0.27.14
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.27.14
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release-pr:
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.27.14
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.27.14
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   security:
     name: Security
-    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.27.14
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.13
+      runtime-ref: v0.27.14
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -55,3 +55,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.slither.outputs.sarif }}
+          category: /language:slither

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [staging]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.27.13
+    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.27.14
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.13
+      runtime-ref: v0.27.14
       runner: ubuntu-latest
       unit-runner: ubuntu-slim
     secrets: inherit


### PR DESCRIPTION
## Summary

- Give Slither SARIF uploads a stable `/language:slither` category.
- Prevent historical Code Scanning configuration mismatches and neutral checks.

## Validation

- Workflow-only change; Code Foundry, tests, and Slither passed on the parent staging commit.