### PR TITLE
chore(code-foundry): upgrade to v0.31.2

### DIFF
--- a/.github/code-foundry.yml
+++ b/.github/code-foundry.yml
@@ -4,7 +4,7 @@ languages: typescript,solidity
 features: all
 package_manager: bun
 runtime_repository: 0xPlayerOne/code-foundry
-runtime_ref: v0.27.15
+runtime_ref: v0.31.2
 runner: ubuntu-latest
 unit_runner: ubuntu-slim
 ci_runner: ubuntu-latest
@@ -26,3 +26,9 @@ merge_strategy: rebase
 codeql: auto
 dependency_review: auto
 toolchain: auto
+post_release: false
+post_release_workflow:
+post_release_mode: auto
+opencode_security: false
+sync_mode: overlay
+custom_workflows: preserve

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/ci.yml@v0.31.2
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.15
+      runtime-ref: v0.31.2
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,9 @@ permissions:
 jobs:
   codeql:
     name: CodeQL
-    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/codeql.yml@v0.31.2
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.15
+      runtime-ref: v0.31.2
       runner: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/draft-pr.yml
+++ b/.github/workflows/draft-pr.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   draft-pr:
     name: Draft PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/draft-pr.yml@v0.31.2
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release-pr:
     name: Release PR
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release-pr.yml@v0.31.2
     with:
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -14,7 +15,9 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/release.yml@v0.31.2
     with:
       runner: ubuntu-slim
+      runtime-repository: 0xPlayerOne/code-foundry
+      runtime-ref: v0.31.2
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,9 @@ permissions:
 jobs:
   security:
     name: Security
-    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/security.yml@v0.31.2
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.15
+      runtime-ref: v0.31.2
       runner: ubuntu-slim
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ permissions:
 jobs:
   test:
     name: Test
-    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.27.15
+    uses: 0xPlayerOne/code-foundry/.github/workflows/test.yml@v0.31.2
     with:
       runtime-repository: 0xPlayerOne/code-foundry
-      runtime-ref: v0.27.15
+      runtime-ref: v0.31.2
       runner: ubuntu-latest
       unit-runner: ubuntu-slim
     secrets: inherit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,10 @@
+# Generated release metadata is intentionally managed by Release Please.
+CHANGELOG.md
+
+# Runtime files are checked out under .github during CI.
+.github/.code-foundry
+
+# Repository-specific rules
 node_modules
 .code-foundry
 .vscode
@@ -5,7 +12,6 @@ node_modules
 .env
 /.DS_Store
 pnpm-lock.yaml
-
 # Hardhat files
 artifacts
 cache
@@ -14,14 +20,11 @@ typechain
 gasReporterOutput.json
 Flattened.sol
 SLITHER.md
-
 #Coverage
 coverage*
 coverage.json
-
 # openzeppelin dev files
 .openzeppelin
-
 # Logs
 logs
 *.log

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -1,0 +1,19 @@
+# Code Foundry extension points
+
+Code Foundry uses an overlay model. The files in its documented baseline are managed by `sync`; repository-owned files outside that baseline remain yours.
+
+## Managed files
+
+The standard workflows, hooks, governance documents, language configuration, and release configuration are refreshed from the configured runtime. Keep repository-specific behavior in separate files.
+
+## Custom workflows
+
+Any workflow not named by the baseline is preserved automatically. This is the supported place for project-specific workflows such as Slither, search indexing, deployment, Docker publishing, or Vercel tasks.
+
+Set `custom_workflows: preserve` in `.github/code-foundry.yml` (the default). Code Foundry intentionally has no prune mode for custom workflows; remove those files explicitly when they are no longer needed.
+
+## Release and deployment hooks
+
+Use `post_release`, `post_release_workflow`, and `post_release_mode` for a post-release artifact workflow. The hook receives `release-tag` and `delivery-key` inputs and is dispatched at most once per tag when a release token is available.
+
+Keep deployment credentials, environment files, and project-specific secrets in the repository or organization configuration. Code Foundry never copies secret values or overwrites custom workflows in overlay mode.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,15 +2,47 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "deps", "section": "Dependencies" },
-    { "type": "docs", "section": "Documentation" },
-    { "type": "test", "section": "Tests" },
-    { "type": "ci", "section": "CI" },
-    { "type": "refactor", "section": "Maintenance" },
-    { "type": "chore", "section": "Maintenance" }
-  ]
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "test",
+      "section": "Tests"
+    },
+    {
+      "type": "ci",
+      "section": "CI"
+    },
+    {
+      "type": "refactor",
+      "section": "Maintenance"
+    },
+    {
+      "type": "chore",
+      "section": "Maintenance"
+    }
+  ],
+  "release-type": "node",
+  "extra-files": []
 }


### PR DESCRIPTION
Automated isolated Code Foundry runtime upgrade to v0.31.2.

The sync preserved protected repository-owned documents and custom workflows.