### PR TITLE
ci: split Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       github-actions:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: npm
     directory: /
@@ -19,6 +20,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       npm-dependencies:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: cargo
     directory: /
@@ -29,6 +31,7 @@ updates:
     open-pull-requests-limit: 99
     groups:
       cargo-dependencies:
+        applies-to: version-updates
         patterns: ['*']
   - package-ecosystem: pip
     directory: /
@@ -39,4 +42,5 @@ updates:
     open-pull-requests-limit: 99
     groups:
       python-dependencies:
+        applies-to: version-updates
         patterns: ['*']


### PR DESCRIPTION
Dependabot grouping is now explicitly limited to version updates. Security updates will remain individual PRs so each vulnerability can be reviewed and validated independently.